### PR TITLE
[STEP-11] Distributed Lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,6 @@ infra
 
 ## 6. 동시성 제어 보고서
  - [동시성 제어 보고서](docs/lock.md)
+
+## 7. Redis를 활용한 분산락 적용 보고서
+ - [분산락을 통한 동시성 제어 보고서](docs/distributedLock.md)

--- a/README.md
+++ b/README.md
@@ -45,3 +45,6 @@ infra
 
 ## 7. Redis를 활용한 분산락 적용 보고서
  - [분산락을 통한 동시성 제어 보고서](docs/distributedLock.md)
+
+## 8. Redis를 활용한 캐시 보고서
+ - [Redis를 활용한 캐시 보고서](docs/cache.md)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-aop")
 	implementation("org.springframework.retry:spring-retry")
+	implementation("org.redisson:redisson-spring-boot-starter:3.46.0")
 
 	// lombok
 	compileOnly("org.projectlombok:lombok")

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,0 +1,88 @@
+# Redis를 활용한 캐시 보고서
+
+수 많은 주문이 발생하는 경우, 현재 제공되는 '인기 상품 조회' API는 DB에 큰 부하를 발생시킬 수 있습니다.
+
+이에 따라서 Redis를 활용하여 해당 데이터를 캐싱하여 DB를 조회하지 않더라도 레디스 메모리를 활용하도록 하겠습니다.
+
+```java
+    @Transactional(readOnly = true)
+    @Cacheable(
+            cacheNames = "popularProducts",
+            key        = "#command.startDate().toString() + '_' + #command.endDate().toString()"
+    )
+    public PopularProducts getPopularProducts(StatsCommand.PopularProducts command) {
+        return new PopularProducts(statsRepository.getPopularProducts(command.startDate(), command.endDate()));
+    }
+```
+
+해당 데이터의 TTL은 25시간으로 세팅해두었으며, 자정에 해당 데이터들이 업데이트됩니다. 
+또한, key세팅을 통하여 로테이션 방식으로 해당 데이터를 캐싱하게됩니다.
+
+
+
+```java
+    @DisplayName("3일간 가장 판매가 많았던 상품 5개를 조회할 수 있다.")
+@Test
+@Sql(scripts = "/sql/popularProduct.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+void popularProducts() {
+    // given // when
+    Objects.requireNonNull(redisCacheManager.getCache("popularProducts")).clear();
+    StatsCommand.PopularProducts command = new StatsCommand.PopularProducts(LocalDate.now().minusDays(3), LocalDate.now().minusDays(1));
+    PopularProducts popularProducts = statsService.getPopularProducts(command);
+
+    // then
+    assertThat(popularProducts.getProducts()).hasSize(5);
+}
+
+@DisplayName("3일간 가장 판매가 많았던 상품이 조회되지 않는 경우 빈 배열이 반환된다.")
+@Test
+void emptyPopularProducts() {
+    // given // when
+    Objects.requireNonNull(redisCacheManager.getCache("popularProducts")).clear();
+    StatsCommand.PopularProducts command = new StatsCommand.PopularProducts(LocalDate.now().minusDays(3), LocalDate.now().minusDays(1));
+    PopularProducts popularProducts = statsService.getPopularProducts(command);
+
+    // then
+    assertThat(popularProducts.getProducts()).isEmpty();
+}
+```
+캐싱과는 별개로 기존 기능들이 구현되게 하기 위해 캐시 데이터를 클렌징하였습니다.
+
+```java
+    @BeforeEach
+    void setUp() {
+        // 캐시 초기화
+        Cache cache = redisCacheManager.getCache("popularProducts");
+        if (cache != null) {
+            cache.clear();
+        }
+    }
+
+    @DisplayName("해당 데이터를 최초로 조회하는 경우 캐시 데이터에 저장된다.")
+    @Test
+    @Sql(scripts = "/sql/popularProduct.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    void saveCacheData() {
+        // given
+        LocalDate end = LocalDate.now().minusDays(1);
+        LocalDate start = end.minusDays(2);
+        // cache key 계산 (service 메서드의 @Cacheable key 전략과 동일하게)
+        String cacheKey = start.toString() + "_" + end.toString();
+
+        // when
+        StatsCommand.PopularProducts command = new StatsCommand.PopularProducts(start, end);
+
+        statsService.getPopularProducts(command);
+
+        // 캐시에 데이터가 저장되었는지 확인
+        Cache.ValueWrapper wrapper = redisCacheManager
+                .getCache("popularProducts")
+                .get(cacheKey);
+        assertThat(wrapper).isNotNull();
+        PopularProducts products = (PopularProducts)wrapper.get();
+        assertThat(products).isNotNull();
+        assertThat(products.getProducts()).isNotNull();
+        assertThat(products.getProducts()).hasSize(5);
+    }
+```
+
+캐싱 데이터가 실제로 저장되는지 확인하기 위하여 별도의 테스트를 구성하였으며, 정상적으로 통과되는 것을 확인하였습니다.

--- a/docs/distributedLock.md
+++ b/docs/distributedLock.md
@@ -1,0 +1,221 @@
+# 분산락을 통한 동시성 제어 보고서
+
+현재 비관락, 낙관락을 적용하여 동시성 제어를 한 로직은 아래와 같습니다.
+
+1. 주문 시 재고 차감
+2. 포인트 충전과 사용
+3. 쿠폰 발급
+
+해당 기능들은 모두 DB Lock으로 구현되어 있어, DB 부하를 발생시킬 수 있으며,
+서버나 DB가 분산되어 있는 환경에서는 일관된 락을 제공할 수 없습니다.
+
+이에 따라서 Redis를 활용하여 분산락을 적용하여 해당 기능들의 동시성 제어를 진행해보도록 하려고 합니다.
+
+---
+
+## AOP를 활용한 분산락
+
+```java
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface DistributedLock {
+
+    String topic();
+    
+    String key();
+
+    LockType type() default LockType.SIMPLE;
+
+    /** 최대 대기 시간(tryLock) */
+    long waitTime() default 5;
+
+    /** 락 자동 만료 시간(leaseTime) */
+    long leaseTime() default 30;
+
+    /** 시간 단위 */
+    TimeUnit unit() default TimeUnit.SECONDS;
+}
+```
+
+AOP를 활용하여 분산락을 적용할 예정이므로, Annotation을 구성해줍니다.
+
+topic은 lock의 key에 활용될 시그니처이고, lock을 걸 id를 key로 받아서 최종적인 redis lock key를 구성하게 됩니다.
+
+또한, AOP에서 @Order(Ordered.HIGHEST_PRECEDENCE)를 붙여줌으로 써 Transaction 획득보다 lock을 먼저 획득함으로써 
+
+데이터 무결성을 보장합니다.
+
+```java
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Order(Ordered.HIGHEST_PRECEDENCE)   // 트랜잭션 AOP 전에 실행
+public class DistributedLockAspect {
+
+    private final RedissonClient redisson;
+
+    @Around("@annotation(kr.hhplus.be.server.support.config.redis.DistributedLock)")
+    public Object around(ProceedingJoinPoint pjp) throws Throwable {
+        MethodSignature sig = (MethodSignature) pjp.getSignature();
+        Method method = ((MethodSignature) pjp.getSignature()).getMethod();
+        DistributedLock ann = method.getAnnotation(DistributedLock.class);
+
+        List<String> keys = parseKeys(ann.topic(), ann.key(), sig.getParameterNames(), pjp.getArgs());
+
+        List<RLock> locks = getLocks(keys, ann);
+
+        return unlockAndProceed(locks, pjp);
+    }
+    
+    // ...
+}
+```
+
+### 쿠폰 발급 분산락 적용
+
+```java
+    @Transactional
+    @DistributedLock(topic = "coupon", key = "#criteria.couponId", type = LockType.FAIR)
+    public CouponResult.IssueUserCoupon issueUserCoupon(CouponCriteria.IssueUserCoupon criteria) {
+
+        Coupon coupon = couponService.issueValidate(criteria.couponId());
+        UserCoupon userCoupon = userCouponService.issue(criteria.toCommand(coupon));
+        couponService.deduct(criteria.couponId());
+
+        return CouponResult.IssueUserCoupon.from(userCoupon);
+    }
+```
+
+해당 로직은 쿠폰을 발급하는 로직으로, 기존에 deduct 메서드에서 발급 시에만 row에 lock을 걸어 동시성 제어를 구현하였지만,
+
+해당 메서드에 lock을 걸 경우, Transaction이 시작된 후에 lock을 획득하게 되고, lock반환보다 transaction을 종료시키게 되어도
+
+발급 전 쿠폰 유효성 검사를 위한 쿠폰 조회가 이루어지기 때문에, JPA의 1차 캐시에 영향으로 의도치 않은 실패 케이스가 발생하여 Facade에 분산락을 적용하였습니다.
+
+
+### 포인트 충전/사용 분산락 적용
+
+```java
+    @DistributedLock(topic = "point", key = "#command.user.id")
+    @Transactional
+    public Point charge(PointCommand.Charge command) {
+        User user = command.user();
+        Point point = pointRepository.findByUserIdForUpdate(user.getId())
+                .orElseThrow(() -> new IllegalArgumentException("등록되지 않은 회원입니다."));
+        point.charge(command.amount());
+
+        return point;
+    }
+
+    @DistributedLock(topic = "point", key = "#command.user.id")
+    @Transactional
+    public Point use(PointCommand.Use command) {
+        User user = command.user();
+        Point point = pointRepository.findByUserIdForUpdate(user.getId())
+                .orElseThrow(() -> new IllegalArgumentException("등록되지 않은 회원입니다."));
+
+        point.use(command.amount());
+        return point;
+    }
+```
+
+충전과 사용 모두 분산락을 적용하였습니다. 이때, 사용의 경우 '주문' 로직 중간에 진행되기 때문에, AOP에서 Lock을 해제하는 경우
+
+Transaction이 commit 혹은 rollback 이후에 lock을 반환하는 로직을 추가하였습니다.
+
+```java
+    private Object unlockAndProceed(List<RLock> locks, ProceedingJoinPoint pjp) throws Throwable {
+        // 트랜잭션 동기화가 활성화되어 있으면 커밋/롤백 후 해제하도록 등록
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCompletion(int status) {
+                            for (RLock lock : locks) {
+                                if (lock.isHeldByCurrentThread()) {
+                                    lock.unlock();
+                                }
+                            }
+                        }
+                    });
+            // 실제 메서드 실행
+            return pjp.proceed();
+        }
+        // 트랜잭션 없으면, 메서드 종료 후 바로 해제
+        try {
+            return pjp.proceed();
+        } finally {
+            for (RLock lock : locks) {
+                if (lock.isHeldByCurrentThread()) {
+                    lock.unlock();
+                }
+            }
+        }
+    }
+```
+
+### 주문 분산락 적용 (재고 차감)
+
+주문에 분산락을 적용할 때 가장 고민이 되었던 부분은 복수의 상품을 주문하게 되는 경우에 여러 개의 lock을 획득해야 한다는 조건이 있었습니다.
+
+이를 위해서 key를 생성할 때 사용되는 spEL을 위해 criteria 객채에 productId list를 생성해주는 메서드를 추가하였습니다.
+
+```java
+        public List<Long> toLockKeys() {
+            return orderItems.stream()
+                    .map(OrderItem::productId)
+                    .sorted()
+                    .collect(Collectors.toList());
+        }
+```
+
+이후, Aspect에서는 해당 key가 list로 들어올 시 다수의 lock을 생성하는 로직을 추가하여 해당 기능을 구현하였습니다.
+
+```java
+
+private List<String> parseKeys(String topic, String spel, String[] paramNames, Object[] args) {
+
+    Object key = parseKey(spel, paramNames, args);
+    List<String> keys;
+
+    if(key instanceof List) {
+        keys = ((Collection<Object>) key).stream()
+                .map(Object::toString)
+                .map(id -> makeKeyName(topic, id))
+                .sorted()
+                .collect(Collectors.toList());
+    }else if(key != null){
+        keys = List.of(makeKeyName(topic, key.toString()));
+    }else {
+        throw new IllegalStateException("올바르지 않은 키 형식입니다.");
+    }
+
+    return keys;
+}
+
+private List<RLock> getLocks(List<String> keys, DistributedLock ann)throws InterruptedException {
+    List<RLock> locks = new ArrayList<>(keys.size());
+
+    for(String lockKey : keys){
+        RLock lock = ann.type() == LockType.FAIR
+                ? redisson.getFairLock(lockKey) : redisson.getLock(lockKey);
+
+        boolean acquired = lock.tryLock(
+                ann.waitTime(), ann.leaseTime(), ann.unit());
+
+        if (!acquired) {
+            locks.forEach(l -> {
+                if (l.isHeldByCurrentThread()) l.unlock();
+            });
+            throw new IllegalStateException("락 획득 실패: " + lockKey);
+        }
+
+        locks.add(lock);
+    }
+
+    return locks;
+}
+```
+
+단일 키로 주어도, 로직을 통일시키기 위해 list로 변환하였고, 이를 통해 한 method에서 다수의 lock을 생성하는 케이스도 커버하였습니다.

--- a/src/main/java/kr/hhplus/be/server/application/coupon/CouponFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/coupon/CouponFacade.java
@@ -22,7 +22,7 @@ public class CouponFacade {
     private final UserCouponService userCouponService;
 
     @Transactional
-    @DistributedLock(key = "'lock:coupon:' + #id", type = LockType.FAIR)
+    @DistributedLock(topic = "coupon", key = "#criteria.couponId", type = LockType.FAIR)
     public CouponResult.IssueUserCoupon issueUserCoupon(CouponCriteria.IssueUserCoupon criteria) {
 
         Coupon coupon = couponService.issueValidate(criteria.couponId());

--- a/src/main/java/kr/hhplus/be/server/application/coupon/CouponFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/coupon/CouponFacade.java
@@ -5,6 +5,8 @@ import kr.hhplus.be.server.domain.coupon.CouponService;
 import kr.hhplus.be.server.domain.user.UserService;
 import kr.hhplus.be.server.domain.userCoupon.UserCoupon;
 import kr.hhplus.be.server.domain.userCoupon.UserCouponService;
+import kr.hhplus.be.server.support.config.redis.DistributedLock;
+import kr.hhplus.be.server.support.config.redis.LockType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,11 +15,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CouponFacade {
 
+    //TODO 제거
     private final UserService userService;
+
     private final CouponService couponService;
     private final UserCouponService userCouponService;
 
     @Transactional
+    @DistributedLock(key = "'lock:coupon:' + #id", type = LockType.FAIR)
     public CouponResult.IssueUserCoupon issueUserCoupon(CouponCriteria.IssueUserCoupon criteria) {
 
         Coupon coupon = couponService.issueValidate(criteria.couponId());

--- a/src/main/java/kr/hhplus/be/server/application/coupon/CouponFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/coupon/CouponFacade.java
@@ -2,7 +2,6 @@ package kr.hhplus.be.server.application.coupon;
 
 import kr.hhplus.be.server.domain.coupon.Coupon;
 import kr.hhplus.be.server.domain.coupon.CouponService;
-import kr.hhplus.be.server.domain.user.UserService;
 import kr.hhplus.be.server.domain.userCoupon.UserCoupon;
 import kr.hhplus.be.server.domain.userCoupon.UserCouponService;
 import kr.hhplus.be.server.support.config.redis.DistributedLock;
@@ -14,9 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class CouponFacade {
-
-    //TODO 제거
-    private final UserService userService;
 
     private final CouponService couponService;
     private final UserCouponService userCouponService;

--- a/src/main/java/kr/hhplus/be/server/application/order/OrderCriteria.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/OrderCriteria.java
@@ -4,6 +4,7 @@ import kr.hhplus.be.server.domain.product.ProductCommand;
 import kr.hhplus.be.server.domain.user.User;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public record OrderCriteria(
 
@@ -13,6 +14,13 @@ public record OrderCriteria(
             Long userCouponId,
             List<OrderItem> orderItems
     ) {
+
+        public List<Long> toLockKeys() {
+            return orderItems.stream()
+                    .map(OrderItem::productId)
+                    .sorted()
+                    .collect(Collectors.toList());
+        }
 
         public void toProductCommand() {
 

--- a/src/main/java/kr/hhplus/be/server/application/order/OrderFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/OrderFacade.java
@@ -10,7 +10,6 @@ import kr.hhplus.be.server.domain.payment.PaymentService;
 import kr.hhplus.be.server.domain.product.ProductInfo;
 import kr.hhplus.be.server.domain.product.ProductService;
 import kr.hhplus.be.server.domain.user.User;
-import kr.hhplus.be.server.domain.user.UserService;
 import kr.hhplus.be.server.domain.userCoupon.UserCouponCommand;
 import kr.hhplus.be.server.domain.userCoupon.UserCouponInfo;
 import kr.hhplus.be.server.domain.userCoupon.UserCouponService;
@@ -25,8 +24,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class OrderFacade {
 
-    //TODO 제거
-    private final UserService userService;
     private final ProductService productService;
     private final UserCouponService userCouponService;
     private final OrderService orderService;

--- a/src/main/java/kr/hhplus/be/server/application/order/OrderFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/OrderFacade.java
@@ -14,6 +14,7 @@ import kr.hhplus.be.server.domain.user.UserService;
 import kr.hhplus.be.server.domain.userCoupon.UserCouponCommand;
 import kr.hhplus.be.server.domain.userCoupon.UserCouponInfo;
 import kr.hhplus.be.server.domain.userCoupon.UserCouponService;
+import kr.hhplus.be.server.support.config.redis.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +25,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class OrderFacade {
 
+    //TODO 제거
     private final UserService userService;
     private final ProductService productService;
     private final UserCouponService userCouponService;
@@ -32,6 +34,7 @@ public class OrderFacade {
 
 
     @Transactional
+    @DistributedLock(topic = "product", key = "#criteria.toLockKeys()")
     public OrderResult order(OrderCriteria.Create criteria) {
 
         User user = criteria.user();

--- a/src/main/java/kr/hhplus/be/server/application/scheduler/StatsScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/application/scheduler/StatsScheduler.java
@@ -14,11 +14,11 @@ public class StatsScheduler {
 
     private final StatsService salesService;
 
-    @Scheduled(cron = "0 0 * * * *")
+    @Scheduled(cron = "0 0 0 * * *")
     public void hourlySalesProducts() {
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime today = LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth(),
-                now.getHour() - 1, 0, 0);
+        LocalDateTime today = LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth() - 1,
+                0, 0, 0);
         StatsCommand.SaveSalesProducts command = new StatsCommand.SaveSalesProducts(today);
         salesService.saveSalesProductByDateTime(command);
     }

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/Coupon.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/Coupon.java
@@ -21,9 +21,6 @@ public class Coupon extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Version
-    private Long version;
-
     private String name;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/kr/hhplus/be/server/domain/point/Point.java
+++ b/src/main/java/kr/hhplus/be/server/domain/point/Point.java
@@ -24,9 +24,6 @@ public class Point extends BaseEntity {
 
     private int balance;
 
-    @Version
-    private Long version;
-
     public static Point create(User user, int balance) {
         return new Point(user, balance);
     }

--- a/src/main/java/kr/hhplus/be/server/domain/point/PointService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/point/PointService.java
@@ -19,7 +19,7 @@ public class PointService {
                 .orElseThrow(() -> new IllegalArgumentException("등록되지 않은 회원입니다."));
     }
 
-    @DistributedLock(key = "'lock:point:' + #command.user.id")
+    @DistributedLock(topic = "point", key = "#command.user.id")
     @Transactional
     public Point charge(PointCommand.Charge command) {
         User user = command.user();
@@ -30,7 +30,7 @@ public class PointService {
         return point;
     }
 
-    @DistributedLock(key = "'lock:point:' + #command.user.id")
+    @DistributedLock(topic = "point", key = "#command.user.id")
     @Transactional
     public Point use(PointCommand.Use command) {
         User user = command.user();

--- a/src/main/java/kr/hhplus/be/server/domain/point/PointService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/point/PointService.java
@@ -2,10 +2,8 @@ package kr.hhplus.be.server.domain.point;
 
 
 import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.support.config.redis.DistributedLock;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.OptimisticLockingFailureException;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,19 +19,18 @@ public class PointService {
                 .orElseThrow(() -> new IllegalArgumentException("등록되지 않은 회원입니다."));
     }
 
-    @Retryable(
-            retryFor = OptimisticLockingFailureException.class,
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 100, multiplier = 2)      // 100ms → 200ms → 400ms
-    )
+    @DistributedLock(key = "'lock:point:' + #command.user.id")
     @Transactional
     public Point charge(PointCommand.Charge command) {
-        Point point = find(command.user());
+        User user = command.user();
+        Point point = pointRepository.findByUserIdForUpdate(user.getId())
+                .orElseThrow(() -> new IllegalArgumentException("등록되지 않은 회원입니다."));
         point.charge(command.amount());
 
         return point;
     }
 
+    @DistributedLock(key = "'lock:point:' + #command.user.id")
     @Transactional
     public Point use(PointCommand.Use command) {
         User user = command.user();

--- a/src/main/java/kr/hhplus/be/server/domain/stats/PopularProduct.java
+++ b/src/main/java/kr/hhplus/be/server/domain/stats/PopularProduct.java
@@ -7,4 +7,5 @@ public record PopularProduct(
         int price,
         int stock
 ) {
+
 }

--- a/src/main/java/kr/hhplus/be/server/domain/stats/PopularProducts.java
+++ b/src/main/java/kr/hhplus/be/server/domain/stats/PopularProducts.java
@@ -1,0 +1,17 @@
+package kr.hhplus.be.server.domain.stats;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PopularProducts {
+     private List<PopularProduct> products = new ArrayList<>();
+
+     public PopularProducts(List<PopularProduct> products) {
+         this.products = products;
+     }
+ }

--- a/src/main/java/kr/hhplus/be/server/domain/stats/StatsCommand.java
+++ b/src/main/java/kr/hhplus/be/server/domain/stats/StatsCommand.java
@@ -1,8 +1,17 @@
 package kr.hhplus.be.server.domain.stats;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record StatsCommand() {
+
+    public record PopularProducts(
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+
+    }
+
     public record SaveSalesProducts (
             LocalDateTime dateTime
     ) {

--- a/src/main/java/kr/hhplus/be/server/domain/stats/StatsRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/stats/StatsRepository.java
@@ -2,11 +2,12 @@ package kr.hhplus.be.server.domain.stats;
 
 import kr.hhplus.be.server.infra.stats.SalesProductSummary;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface StatsRepository {
-    List<PopularProduct> getPopularProducts();
+    List<PopularProduct> getPopularProducts(LocalDate startDate, LocalDate endDate);
     List<SalesProductSummary> findSalesProductSummaryByDateTime(LocalDateTime datetime);
     void batchInsert(List<SalesProductSummary> products);
 }

--- a/src/main/java/kr/hhplus/be/server/domain/stats/StatsService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/stats/StatsService.java
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.domain.stats;
 
 import kr.hhplus.be.server.infra.stats.SalesProductSummary;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,8 +15,12 @@ public class StatsService {
     private final StatsRepository statsRepository;
 
     @Transactional(readOnly = true)
-    public List<PopularProduct> getPopularProducts() {
-        return statsRepository.getPopularProducts();
+    @Cacheable(
+            cacheNames = "popularProducts",
+            key        = "#command.startDate().toString() + '_' + #command.endDate().toString()"
+    )
+    public PopularProducts getPopularProducts(StatsCommand.PopularProducts command) {
+        return new PopularProducts(statsRepository.getPopularProducts(command.startDate(), command.endDate()));
     }
 
     @Transactional

--- a/src/main/java/kr/hhplus/be/server/infra/stats/JpaStatsRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infra/stats/JpaStatsRepository.java
@@ -12,16 +12,25 @@ import java.util.List;
 public interface JpaStatsRepository extends JpaRepository<SalesProduct, Long> {
 
     @Query(value = """
-        SELECT s.product_id AS productId
-                 , SUM(s.sales_count) totalQuantity
-                 , p.name, p.price, p.stock
+        SELECT 
+            s.product_id        AS productId,
+            SUM(s.sales_count)  AS totalQuantity,
+            p.name              AS name,
+            p.price             AS price,
+            p.stock             AS stock
         FROM stats_daily_product_sales s
-            JOIN product p on p.id = s.product_id
-        WHERE s.order_date >= DATE_SUB(CURDATE(), INTERVAL 3 DAY)
-        GROUP BY s.product_id, p.name, p.price, p.stock
-        ORDER BY totalQuantity DESC LIMIT 5;
+        JOIN product p 
+          ON p.id = s.product_id
+        WHERE s.order_date BETWEEN :startDate AND :endDate
+        GROUP BY 
+            s.product_id,
+            p.name,
+            p.price,
+            p.stock
+        ORDER BY totalQuantity DESC
+        LIMIT 5
     """, nativeQuery = true)
-    List<NativePopularProduct> getPopularProducts();
+    List<NativePopularProduct> getPopularProducts(LocalDate startDate, LocalDate endDate);
 
     @Query(value = """
     SELECT

--- a/src/main/java/kr/hhplus/be/server/infra/stats/JpaStatsRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infra/stats/JpaStatsRepository.java
@@ -25,14 +25,14 @@ public interface JpaStatsRepository extends JpaRepository<SalesProduct, Long> {
 
     @Query(value = """
     SELECT
-      op.product_id          AS productId,
-      SUM(op.quantity)       AS salesCount,
-      CURDATE()              AS orderDate
+      op.product_id            AS productId,
+      SUM(op.quantity)         AS salesCount,
+      DATE(o.order_date_time)  AS orderDate
     FROM orders o
     JOIN order_product op ON op.order_id = o.id
     WHERE o.order_date_time >= :dateTime
       AND o.status = 'SUCCESS'
-    GROUP BY op.product_id
+    GROUP BY op.product_id, orderDate
     ORDER BY salesCount DESC
     """, nativeQuery = true)
     List<SalesProductSummary> findSalesProductByDateTime(@Param("dateTime")LocalDateTime dateTime);

--- a/src/main/java/kr/hhplus/be/server/infra/stats/StatsRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infra/stats/StatsRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -39,8 +40,8 @@ public class StatsRepositoryImpl implements StatsRepository {
     }
 
     @Override
-    public List<PopularProduct> getPopularProducts() {
-        List<NativePopularProduct> NativePopularProducts = jpaStatsRepository.getPopularProducts();
+    public List<PopularProduct> getPopularProducts(LocalDate startDate, LocalDate endDate) {
+        List<NativePopularProduct> NativePopularProducts = jpaStatsRepository.getPopularProducts(startDate, endDate);
         return NativePopularProducts.stream().map(NativePopularProduct -> {
             return new PopularProduct(NativePopularProduct.getProductId(), NativePopularProduct.getTotalQuantity(), NativePopularProduct.getName(), NativePopularProduct.getPrice(), NativePopularProduct.getStock());
         }).toList();

--- a/src/main/java/kr/hhplus/be/server/interfaces/stats/StatsController.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/stats/StatsController.java
@@ -1,13 +1,12 @@
 package kr.hhplus.be.server.interfaces.stats;
 
-import kr.hhplus.be.server.domain.stats.PopularProduct;
+import kr.hhplus.be.server.domain.stats.PopularProducts;
 import kr.hhplus.be.server.domain.stats.StatsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,8 +15,9 @@ public class StatsController implements StatsDocs{
     private final StatsService statsService;
 
     @GetMapping("/api/v1/stats/products/popular")
-    public ResponseEntity<StatsResponse.PopularProductResponse> popularProduct(){
-        List<PopularProduct> popularProducts = statsService.getPopularProducts();
-        return ResponseEntity.ok(StatsResponse.PopularProductResponse.from(popularProducts));
+    public ResponseEntity<StatsResponse.PopularProductResponse> popularProduct(@ModelAttribute StatsRequest request){
+
+        PopularProducts result = statsService.getPopularProducts(request.toCommand());
+        return ResponseEntity.ok(StatsResponse.PopularProductResponse.from(result.getProducts()));
     }
 }

--- a/src/main/java/kr/hhplus/be/server/interfaces/stats/StatsDocs.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/stats/StatsDocs.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.hhplus.be.server.interfaces.product.ProductResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
 
 @Tag(name = "stats", description = "stats API")
 public interface StatsDocs {
@@ -65,5 +66,5 @@ public interface StatsDocs {
                     )
             )
     })
-    public ResponseEntity<StatsResponse.PopularProductResponse> popularProduct();
+    public ResponseEntity<StatsResponse.PopularProductResponse> popularProduct(@ModelAttribute StatsRequest request);
 }

--- a/src/main/java/kr/hhplus/be/server/interfaces/stats/StatsRequest.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/stats/StatsRequest.java
@@ -1,0 +1,15 @@
+package kr.hhplus.be.server.interfaces.stats;
+
+import kr.hhplus.be.server.domain.stats.StatsCommand;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+public record StatsRequest(
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+) {
+    public StatsCommand.PopularProducts toCommand() {
+        return new StatsCommand.PopularProducts(startDate, endDate);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/support/config/CacheConfig.java
+++ b/src/main/java/kr/hhplus/be/server/support/config/CacheConfig.java
@@ -1,0 +1,42 @@
+package kr.hhplus.be.server.support.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory cf) {
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.NON_FINAL
+        );
+
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(mapper)))
+                .entryTtl(Duration.ofHours(1));
+
+        return RedisCacheManager.builder(cf)
+                .cacheDefaults(defaultConfig)
+                .withCacheConfiguration("popularProducts",
+                        defaultConfig.entryTtl(Duration.ofHours(25)))
+                .build();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/support/config/redis/DistributedLock.java
+++ b/src/main/java/kr/hhplus/be/server/support/config/redis/DistributedLock.java
@@ -18,9 +18,12 @@ import java.util.concurrent.TimeUnit;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface DistributedLock {
+
+    String topic();
+
     /**
      * 락의 키(SpEL 가능)
-     * ex) "lock:point:" + "#userId"
+     * ex) "#userId"
      */
     String key();
 

--- a/src/main/java/kr/hhplus/be/server/support/config/redis/DistributedLock.java
+++ b/src/main/java/kr/hhplus/be/server/support/config/redis/DistributedLock.java
@@ -1,0 +1,37 @@
+package kr.hhplus.be.server.support.config.redis;
+
+import java.lang.annotation.*;
+import java.util.concurrent.TimeUnit;
+
+/*
+*
+* @Transaction
+  @RedisLock(
+      key = "'lock:point:' + #userId",
+      waitTime = 5, leaseTime = 30, type = LockType.FAIR, unit = TimeUnit.SECONDS)
+* charge(){
+*  ...
+* }
+*
+* */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface DistributedLock {
+    /**
+     * 락의 키(SpEL 가능)
+     * ex) "lock:point:" + "#userId"
+     */
+    String key();
+
+    LockType type() default LockType.SIMPLE;
+
+    /** 최대 대기 시간(tryLock) */
+    long waitTime() default 5;
+
+    /** 락 자동 만료 시간(leaseTime) */
+    long leaseTime() default 30;
+
+    /** 시간 단위 */
+    TimeUnit unit() default TimeUnit.SECONDS;
+}

--- a/src/main/java/kr/hhplus/be/server/support/config/redis/DistributedLockAspect.java
+++ b/src/main/java/kr/hhplus/be/server/support/config/redis/DistributedLockAspect.java
@@ -1,0 +1,82 @@
+package kr.hhplus.be.server.support.config.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.lang.reflect.Method;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Order(Ordered.HIGHEST_PRECEDENCE)   // 트랜잭션 AOP 전에 실행
+public class DistributedLockAspect {
+
+    private final RedissonClient redisson;
+
+    @Around("@annotation(kr.hhplus.be.server.support.config.redis.DistributedLock)")
+    public Object around(ProceedingJoinPoint pjp) throws Throwable {
+        MethodSignature sig = (MethodSignature) pjp.getSignature();
+        Method method = ((MethodSignature) pjp.getSignature()).getMethod();
+        DistributedLock ann = method.getAnnotation(DistributedLock.class);
+
+        String lockKey = parseKey(ann.key(), sig.getParameterNames(), pjp.getArgs());
+
+        RLock lock = ann.type() == LockType.FAIR
+                ? redisson.getFairLock(lockKey) : redisson.getLock(lockKey);
+
+        boolean acquired = lock.tryLock(
+                ann.waitTime(), ann.leaseTime(), ann.unit());
+        if (!acquired) {
+            throw new IllegalStateException("락 획득 실패: " + lockKey);
+        }
+        // 트랜잭션 동기화가 활성화되어 있으면 커밋/롤백 후 해제하도록 등록
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCompletion(int status) {
+                            if (lock.isHeldByCurrentThread()) {
+                                lock.unlock();
+                            }
+                        }
+                    });
+            // 실제 메서드 실행
+            return pjp.proceed();
+        }
+        // 트랜잭션 없으면, 메서드 종료 후 바로 해제
+        try {
+            return pjp.proceed();
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+
+    private String parseKey(String spel, String[] paramNames, Object[] args) {
+        // 1) SpEL 파서 & 컨텍스트
+        StandardEvaluationContext ctx = new StandardEvaluationContext();
+
+        // 2) 파라미터 이름과 값을 컨텍스트에 바인딩
+        for (int i = 0; i < paramNames.length; i++) {
+            ctx.setVariable(paramNames[i], args[i]);
+        }
+
+        // 3) SpEL 평가 후 키 반환
+        return new SpelExpressionParser()
+                .parseExpression(spel)
+                .getValue(ctx, String.class);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/support/config/redis/LockType.java
+++ b/src/main/java/kr/hhplus/be/server/support/config/redis/LockType.java
@@ -1,0 +1,6 @@
+package kr.hhplus.be.server.support.config.redis;
+
+public enum LockType {
+    FAIR,
+    SIMPLE
+}

--- a/src/main/java/kr/hhplus/be/server/support/config/redis/RedisConfig.java
+++ b/src/main/java/kr/hhplus/be/server/support/config/redis/RedisConfig.java
@@ -1,0 +1,25 @@
+package kr.hhplus.be.server.support.config.redis;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisConfig {
+
+//    @Bean
+//    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
+//        RedisTemplate<String, Object> template = new RedisTemplate<>();
+//        template.setConnectionFactory(factory);
+//
+//        // 키는 문자열
+//        template.setKeySerializer(new StringRedisSerializer());
+//        template.setHashKeySerializer(new StringRedisSerializer());
+//
+//        // 값은 JSON 직렬화
+//        RedisSerializer<Object> java = RedisSerializer.java();
+//        template.setValueSerializer(java);
+//        template.setHashValueSerializer(java);
+//
+//        template.afterPropertiesSet();
+//        return template;
+//    }
+}

--- a/src/main/java/kr/hhplus/be/server/support/config/redis/RedissonConfig.java
+++ b/src/main/java/kr/hhplus/be/server/support/config/redis/RedissonConfig.java
@@ -1,0 +1,29 @@
+package kr.hhplus.be.server.support.config.redis;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Bean(destroyMethod="shutdown")
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        // 단일 서버 모드 설정
+        config.useSingleServer()
+                .setAddress("redis://localhost:6379")
+                .setConnectionPoolSize(64)
+                .setConnectionMinimumIdleSize(24)
+                .setSubscriptionConnectionPoolSize(50)
+                .setIdleConnectionTimeout(10000)
+                .setConnectTimeout(10000)
+                .setTimeout(3000)
+                .setRetryAttempts(3)
+                .setRetryInterval(1500);
+
+        return Redisson.create(config);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,3 +38,8 @@ spring:
         format_sql: true
         highlight_sql: true
         use_sql_comments: true
+
+data:
+  redis:
+    host: redis
+    port: 6379

--- a/src/main/resources/sql/saveSalesProduct.sql
+++ b/src/main/resources/sql/saveSalesProduct.sql
@@ -8,11 +8,11 @@ INSERT INTO product (id, name, price, stock, created_at, modified_at) VALUES (2,
 INSERT INTO product (id, name, price, stock, created_at, modified_at) VALUES (3, 'product3', 3000, 30, '2025-04-17 16:03:30', '2025-04-17 16:03:30');
 INSERT INTO product (id, name, price, stock, created_at, modified_at) VALUES (4, 'product4', 4000, 40, '2025-04-17 16:03:30', '2025-04-17 16:03:30');
 INSERT INTO product (id, name, price, stock, created_at, modified_at) VALUES (5, 'product5', 5000, 50, '2025-04-17 16:03:30', '2025-04-17 16:03:30');
-INSERT INTO orders (id, order_amount, final_amount, order_date_time, created_at, modified_at, user_id, status) VALUES (1, 1000, 1000, NOW(), NOW(), NOW(), 1, 'SUCCESS');
-INSERT INTO orders (id, order_amount, final_amount, order_date_time, created_at, modified_at, user_id, status) VALUES (2, 2000, 2000, NOW(), NOW(), NOW(), 2, 'SUCCESS');
-INSERT INTO orders (id, order_amount, final_amount, order_date_time, created_at, modified_at, user_id, status) VALUES (3, 3000, 3000, NOW(), NOW(), NOW(), 3, 'SUCCESS');
-INSERT INTO orders (id, order_amount, final_amount, order_date_time, created_at, modified_at, user_id, status) VALUES (4, 4000, 4000, NOW(), NOW(), NOW(), 4, 'SUCCESS');
-INSERT INTO orders (id, order_amount, final_amount, order_date_time, created_at, modified_at, user_id, status) VALUES (5, 5000, 5000, NOW(), NOW(), NOW(), 5, 'SUCCESS');
+INSERT INTO orders (id, order_amount, final_amount, order_date_time, created_at, modified_at, user_id, status) VALUES (1, 1000, 1000, '2025-04-17 16:03:30', NOW(), NOW(), 1, 'SUCCESS');
+INSERT INTO orders (id, order_amount, final_amount, order_date_time, created_at, modified_at, user_id, status) VALUES (2, 2000, 2000, '2025-04-17 16:03:30', NOW(), NOW(), 2, 'SUCCESS');
+INSERT INTO orders (id, order_amount, final_amount, order_date_time, created_at, modified_at, user_id, status) VALUES (3, 3000, 3000, '2025-04-17 16:03:30', NOW(), NOW(), 3, 'SUCCESS');
+INSERT INTO orders (id, order_amount, final_amount, order_date_time, created_at, modified_at, user_id, status) VALUES (4, 4000, 4000, '2025-04-17 16:03:30', NOW(), NOW(), 4, 'SUCCESS');
+INSERT INTO orders (id, order_amount, final_amount, order_date_time, created_at, modified_at, user_id, status) VALUES (5, 5000, 5000, '2025-04-17 16:03:30', NOW(), NOW(), 5, 'SUCCESS');
 INSERT INTO order_product (id, price, quantity, order_id, product_id, name) VALUES (1, 1000, 1, 1, 1, 'product1');
 INSERT INTO order_product (id, price, quantity, order_id, product_id, name) VALUES (2, 2000, 2, 2, 2, 'product2');
 INSERT INTO order_product (id, price, quantity, order_id, product_id, name) VALUES (3, 3000, 3, 3, 3, 'product3');

--- a/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
+++ b/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
@@ -1,10 +1,8 @@
 package kr.hhplus.be.server;
 
 import jakarta.annotation.PreDestroy;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -12,6 +10,7 @@ import org.testcontainers.utility.DockerImageName;
 class TestcontainersConfiguration {
 
 	public static final MySQLContainer<?> MYSQL_CONTAINER;
+	private static final GenericContainer REDIS_CONTAINER;
 
 	static {
 		MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
@@ -23,12 +22,23 @@ class TestcontainersConfiguration {
 		System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
 		System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
 		System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
+
+		REDIS_CONTAINER = new GenericContainer(DockerImageName.parse("redis:7.0.11-alpine"))
+				.withReuse(true)
+				.withExposedPorts(6379);
+		REDIS_CONTAINER.start();
+
+		System.setProperty("data.redis.host", REDIS_CONTAINER.getHost());
+		System.setProperty("data.redis.port", REDIS_CONTAINER.getFirstMappedPort().toString());
 	}
 
 	@PreDestroy
 	public void preDestroy() {
 		if (MYSQL_CONTAINER.isRunning()) {
 			MYSQL_CONTAINER.stop();
+		}
+		if (REDIS_CONTAINER.isRunning()) {
+			REDIS_CONTAINER.stop();
 		}
 	}
 }

--- a/src/test/java/kr/hhplus/be/server/application/coupon/CouponConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/coupon/CouponConcurrencyTest.java
@@ -1,0 +1,78 @@
+package kr.hhplus.be.server.application.coupon;
+
+import kr.hhplus.be.server.domain.coupon.Coupon;
+import kr.hhplus.be.server.domain.coupon.CouponType;
+import kr.hhplus.be.server.domain.coupon.DiscountType;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.infra.coupon.JpaCouponRepository;
+import kr.hhplus.be.server.infra.user.JpaUserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class CouponConcurrencyTest {
+
+    @Autowired
+    private CouponFacade couponFacade;
+
+    @Autowired
+    private JpaCouponRepository jpaCouponRepository;
+
+    @Autowired
+    private JpaUserRepository jpaUserRepository;
+
+    @DisplayName("동일한 쿠폰에 대한 발급을 요청한 경우 발급된 개수만큼 쿠폰의 잔여 개수가 차감된다.")
+    @Test
+    void issueByCoupon() throws InterruptedException {
+        // given
+        Coupon coupon = Coupon.create("쿠폰", CouponType.TOTAL, DiscountType.FIXED, 1000, 3, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1), 10);
+        jpaCouponRepository.save(coupon);
+
+        int threadCount = 13;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCnt = new AtomicInteger();
+
+        for (int i = 1; i <= threadCount; i++) {
+            User user = User.create("user" + i);
+            jpaUserRepository.save(user);
+        }
+
+        Long couponId = coupon.getId();
+
+        // when
+        for (long i = 1; i <= threadCount; i++) {
+            long userId = i;
+            executorService.submit(() -> {
+                try {
+                    User user = jpaUserRepository.findById(userId).orElseThrow();
+                    CouponCriteria.IssueUserCoupon criteria = new CouponCriteria.IssueUserCoupon(user, couponId);
+                    couponFacade.issueUserCoupon(criteria);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(); // 모든 작업이 끝날 때까지 대기
+
+        // then
+        assertThat(successCnt.get()).isNotZero();
+        Coupon findCoupon = jpaCouponRepository.findById(couponId).orElseThrow();
+        assertThat(findCoupon.getQuantity()).isEqualTo(coupon.getInitialQuantity() - successCnt.get());
+    }
+
+}

--- a/src/test/java/kr/hhplus/be/server/application/coupon/CouponConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/coupon/CouponConcurrencyTest.java
@@ -59,6 +59,7 @@ class CouponConcurrencyTest {
                     User user = jpaUserRepository.findById(userId).orElseThrow();
                     CouponCriteria.IssueUserCoupon criteria = new CouponCriteria.IssueUserCoupon(user, couponId);
                     couponFacade.issueUserCoupon(criteria);
+                    successCnt.getAndIncrement();
                 } catch (Exception e) {
                     e.printStackTrace();
                 } finally {

--- a/src/test/java/kr/hhplus/be/server/application/order/OrderCriteriaTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/order/OrderCriteriaTest.java
@@ -1,0 +1,30 @@
+package kr.hhplus.be.server.application.order;
+
+import kr.hhplus.be.server.domain.user.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OrderCriteriaTest {
+
+
+    @DisplayName("orderItem으로 들어온 productId를 오름차순으로 정렬된 list로 받을 수 있다.")
+    @Test
+    void toLockKeys() {
+        // given
+        OrderCriteria.Create criteria = new OrderCriteria.Create(User.create("1"), 1L
+                , List.of(
+                        new OrderCriteria.Create.OrderItem(3L, 2),
+                new OrderCriteria.Create.OrderItem(5L, 2),
+                new OrderCriteria.Create.OrderItem(7L, 2)));
+
+        // when
+        List<Long> lockKeys = criteria.toLockKeys();
+
+        // then
+        assertThat(lockKeys).containsExactly(3L, 5L, 7L);
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/application/order/OrderFacadeTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/order/OrderFacadeTest.java
@@ -1,0 +1,118 @@
+package kr.hhplus.be.server.application.order;
+
+import kr.hhplus.be.server.domain.point.Point;
+import kr.hhplus.be.server.domain.product.Product;
+import kr.hhplus.be.server.domain.product.ProductRepository;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.infra.order.JpaOrderRepository;
+import kr.hhplus.be.server.infra.payment.JpaPaymentRepository;
+import kr.hhplus.be.server.infra.point.JpaPointRepository;
+import kr.hhplus.be.server.infra.product.JpaProductRepository;
+import kr.hhplus.be.server.infra.user.JpaUserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class OrderFacadeTest {
+
+    @Autowired
+    private OrderFacade orderFacade;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private JpaProductRepository jpaProductRepository;
+
+    @Autowired
+    private JpaUserRepository jpaUserRepository;
+
+    @Autowired
+    private JpaPointRepository jpaPointRepository;
+
+    @Autowired
+    private JpaPaymentRepository jpaPaymentRepository;
+
+    @Autowired
+    private JpaOrderRepository jpaOrderRepository;
+
+    @AfterEach
+    void tearDown() {
+        jpaPaymentRepository.deleteAllInBatch();
+        jpaOrderRepository.deleteAllInBatch();
+        jpaPointRepository.deleteAllInBatch();
+        jpaUserRepository.deleteAllInBatch();
+        jpaProductRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("동시에 동일한 상품으로 주문을 해도 정상적으로 재고가 차감된다.")
+    @Test
+    void concurrencyOrderByProductDeduct() throws InterruptedException {
+        // given
+        Product product1 = productRepository.save(Product.create("사과", 10, 10));
+        Product product2 = productRepository.save(Product.create("배", 10, 10));
+
+
+        int threadCount = 12;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCnt = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            User user = jpaUserRepository.save(User.create("user" + i));
+            jpaPointRepository.save(Point.create(user, 1000));
+        }
+
+        // when
+        for (long i = 1; i <= threadCount; i++) {
+            Long userId = i;
+            executorService.submit(() -> {
+                try{
+                    User user = jpaUserRepository.findById(userId).orElseThrow();
+                    OrderCriteria.Create criteria = new OrderCriteria.Create(user, null, List.of(
+                            new OrderCriteria.Create.OrderItem(product1.getId(), 1),
+                            new OrderCriteria.Create.OrderItem(product2.getId(), 1))
+                    );
+                    orderFacade.order(criteria);
+                    successCnt.getAndIncrement();
+                }catch(Exception e){
+                    e.printStackTrace();
+                }finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(); // 모든 작업이 끝날 때까지 대기
+
+        // then
+        assertThat(successCnt.get()).isNotZero();
+        List<Product> products = jpaProductRepository.findAll();
+        int leftStock = product1.getStock() - successCnt.get();
+        assertThat(products).extracting(Product::getStock)
+                .containsOnly(leftStock, leftStock);
+    }
+
+    @DisplayName("")
+    @Test
+    void concurrencyOrderByPoint() {
+        // given
+
+
+        // when
+
+
+        // then
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/domain/point/PointConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/point/PointConcurrencyTest.java
@@ -3,6 +3,7 @@ package kr.hhplus.be.server.domain.point;
 import kr.hhplus.be.server.domain.user.User;
 import kr.hhplus.be.server.infra.point.JpaPointRepository;
 import kr.hhplus.be.server.infra.user.JpaUserRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,7 +31,13 @@ public class PointConcurrencyTest {
     @Autowired
     private JpaPointRepository jpaPointRepository;
 
-    @DisplayName("동시에 여러번 충전을 진행하여도, 충전을 성공한 만큼만 포인트가 추가된다.")
+    @AfterEach
+    void tearDown() {
+        jpaPointRepository.deleteAllInBatch();
+        jpaUserRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("동시에 여러번 충전을 진행하여도, 충전을 요청한 만큼 포인트가 추가된다.")
     @Test
     void chargeConcurrency() throws InterruptedException{
         // given

--- a/src/test/java/kr/hhplus/be/server/domain/point/PointServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/point/PointServiceTest.java
@@ -56,7 +56,7 @@ class PointServiceTest {
             int originalAmount = 10;
             Point point = Point.create(user, originalAmount);
             int chargeAmount = 10;
-            when(pointRepository.findByUserId(userId)).thenReturn(Optional.of(point));
+            when(pointRepository.findByUserIdForUpdate(userId)).thenReturn(Optional.of(point));
 
             PointCommand.Charge command = new PointCommand.Charge(user, chargeAmount);
             // when
@@ -64,7 +64,7 @@ class PointServiceTest {
 
             // then
             assertThat(charge.getBalance()).isEqualTo(originalAmount + chargeAmount);
-            verify(pointRepository, times(1)).findByUserId(userId);
+            verify(pointRepository, times(1)).findByUserIdForUpdate(userId);
         }
     }
 

--- a/src/test/java/kr/hhplus/be/server/domain/stats/StatsCacheTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/stats/StatsCacheTest.java
@@ -1,0 +1,65 @@
+package kr.hhplus.be.server.domain.stats;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.Cache;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+@Transactional
+public class StatsCacheTest {
+
+    @Autowired
+    private StatsService statsService;
+
+    @Autowired
+    private RedisCacheManager redisCacheManager;
+
+    @BeforeEach
+    void setUp() {
+        // 캐시 초기화
+        Cache cache = redisCacheManager.getCache("popularProducts");
+        if (cache != null) {
+            cache.clear();
+        }
+    }
+
+    @DisplayName("해당 데이터를 최초로 조회하는 경우 캐시 데이터에 저장된다.")
+    @Test
+    @Sql(scripts = "/sql/popularProduct.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    void saveCacheData() {
+        // given
+        LocalDate end = LocalDate.now().minusDays(1);
+        LocalDate start = end.minusDays(2);
+        // cache key 계산 (service 메서드의 @Cacheable key 전략과 동일하게)
+        String cacheKey = start.toString() + "_" + end.toString();
+
+        // when
+        StatsCommand.PopularProducts command = new StatsCommand.PopularProducts(start, end);
+
+        statsService.getPopularProducts(command);
+
+        // 캐시에 데이터가 저장되었는지 확인
+        Cache.ValueWrapper wrapper = redisCacheManager
+                .getCache("popularProducts")
+                .get(cacheKey);
+        assertThat(wrapper).isNotNull();
+        PopularProducts products = (PopularProducts)wrapper.get();
+        assertThat(products).isNotNull();
+        assertThat(products.getProducts()).isNotNull();
+        assertThat(products.getProducts()).hasSize(5);
+    }
+
+}

--- a/src/test/java/kr/hhplus/be/server/domain/stats/StatsServiceIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/stats/StatsServiceIntegrationTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -29,22 +30,23 @@ class StatsServiceIntegrationTest {
     @Sql(scripts = "/sql/saveSalesProduct.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
     void saveSalesProductsByDateTime() {
         // given
-        LocalDateTime dateTime = LocalDateTime.now().minusDays(1);
-        StatsCommand.SaveSalesProducts command = new StatsCommand.SaveSalesProducts(dateTime);
+        LocalDateTime targetDateTime = LocalDateTime.of(2025, 4, 17, 0, 0, 0);
+        StatsCommand.SaveSalesProducts command = new StatsCommand.SaveSalesProducts(targetDateTime);
 
         // when
         statsService.saveSalesProductByDateTime(command);
 
         // then
-        List<SalesProduct> all = jpaStatsRepository.findByOrderDateWithProduct(dateTime.toLocalDate());
+        LocalDate date = targetDateTime.toLocalDate();
+        List<SalesProduct> all = jpaStatsRepository.findByOrderDateWithProduct(date);
         assertThat(all).hasSize(5);
         assertThat(all).extracting("product.id", "salesCount", "orderDate")
                 .containsExactlyInAnyOrder(
-                        tuple(1L, 1L, dateTime.toLocalDate()),
-        tuple(2L, 2L, dateTime.toLocalDate()),
-                tuple(3L, 3L, dateTime.toLocalDate()),
-                tuple(4L, 4L, dateTime.toLocalDate()),
-                tuple(5L, 5L, dateTime.toLocalDate()));
+                        tuple(1L, 1L, date),
+        tuple(2L, 2L, date),
+                tuple(3L, 3L, date),
+                tuple(4L, 4L, date),
+                tuple(5L, 5L, date));
     }
 
     @DisplayName("3일간 가장 판매가 많았던 상품 5개를 조회할 수 있다.")

--- a/src/test/java/kr/hhplus/be/server/domain/stats/StatsServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/stats/StatsServiceTest.java
@@ -60,15 +60,15 @@ class StatsServiceTest {
                 new PopularProduct(3L, 45L, "맥북", 5000, 50),
                 new PopularProduct(4L, 45L, "맥북", 5000, 50),
                 new PopularProduct(5L, 45L, "맥북", 5000, 50));
-
-        when(statsRepository.getPopularProducts()).thenReturn(res);
+        StatsCommand.PopularProducts command = new StatsCommand.PopularProducts(LocalDate.now().minusDays(3), LocalDate.now().minusDays(1));
+        when(statsRepository.getPopularProducts(command.startDate(), command.endDate())).thenReturn(res);
 
         // when
-        List<PopularProduct> popularProducts = statsService.getPopularProducts();
+        PopularProducts popularProducts = statsService.getPopularProducts(command);
 
         // then
         assertThat(popularProducts).isNotNull();
-        verify(statsRepository, times(1)).getPopularProducts();
+        verify(statsRepository, times(1)).getPopularProducts(command.startDate(), command.endDate());
     }
 
 }

--- a/src/test/java/kr/hhplus/be/server/interfaces/stats/StatsControllerTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/stats/StatsControllerTest.java
@@ -1,6 +1,8 @@
 package kr.hhplus.be.server.interfaces.stats;
 
 import kr.hhplus.be.server.domain.stats.PopularProduct;
+import kr.hhplus.be.server.domain.stats.PopularProducts;
+import kr.hhplus.be.server.domain.stats.StatsCommand;
 import kr.hhplus.be.server.domain.stats.StatsService;
 import kr.hhplus.be.server.domain.user.UserService;
 import org.junit.jupiter.api.DisplayName;
@@ -11,6 +13,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
@@ -41,11 +44,14 @@ class StatsControllerTest {
                 new PopularProduct(4L, 1000L, "상품4", 1000, 10),
                 new PopularProduct(5L, 1000L, "상품5", 1000, 10)
         );
-        when(statsService.getPopularProducts()).thenReturn(products);
+        StatsCommand.PopularProducts command = new StatsCommand.PopularProducts(LocalDate.now().minusDays(3), LocalDate.now());
+        when(statsService.getPopularProducts(command)).thenReturn(new PopularProducts(products));
 
 
         // when // then
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/stats/products/popular"))
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/stats/products/popular")
+                        .queryParam("startDate", command.startDate().toString())
+                        .queryParam("endDate", command.endDate().toString()))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.products").isArray())


### PR DESCRIPTION
## ISSUE
 - #31 

## PR 설명
 - Redis 세팅 f73ebf64dbbba527b8f39392b655d183d57c7cea
 - 분산락 AOP 구현 d9f4efe9461700e2d4230d12be9af01b45f269f5
 - 쿠폰 발급 분산락 적용 0e03a0e0b5773380335170d64e7acf7fc0687dbe
 - 주문 시 상품 재고 차감 분산락 적용 abfd7be3db1b3c27e461962fc3b330077c4fa2e7
 - 포인트 충전/사용 분산락 적용 b9094a9f7b4e090276b7b5b0cae7e9e883237f5f
 - 테스트 오류 리팩토링 08bbb4b2e771133fdc1e29c3948b3b6e81d1584f
 - 분산락 적용 보고서 7ff66d36345c174c3cbfb5f496c653a0dec99476

## 리뷰 포인트
쿠폰 발급 시 재고를 차감하는 로직에만 락을 적용하여 범위를 좁히고 싶었으나, JPA 1차 캐시 (재고 차감 전 유효성 검사를 위해 조회를 진행) 때문에 의도치 않은 실패가 많이 발생하여 Facade에 락을 적용하였습니다.(최초 Transaction 시작 전에 lock 획득)
이전에 멘토링 때 언급해주신 Transaction 시작 이후에 lock을 획득하더라도, Transaction 종료 이후에 lock을 반환(ex Spring Event)하여 이슈를 없애는 방법을 적용해보고자 하였는데, lock이 적용되는 데이터의 조회가 lock 획득 전에 이루어지면 동시성 이슈가 발생하게 되는 것 같습니다. flush를 강제로 진행해야 할까요 ? 아니면 다른 방법이 있나요 ? 궁금합니다.